### PR TITLE
[C] Bump next to 15.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "i18next-browser-languagedetector": "^8.0.4",
     "lodash": "^4.17.21",
     "markdown-to-txt": "^2.0.1",
-    "next": "15.4.8",
+    "next": "15.4.10",
     "next-auth": "^5.0.0-beta.29",
     "next-mdx-remote": "^5.0.0",
     "pdfjs-dist": "5.3.93",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,10 +2049,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.4.8":
-  version: 15.4.8
-  resolution: "@next/env@npm:15.4.8"
-  checksum: 10c0/6b0555e30c175a04781a75f0ddc2630bea1af0f31bac0c7875d6063bec9fb2ee50ccf6a3965e532604f40a2c98f1ceb8eb52283b449ba4345ab1b50a0fde8b88
+"@next/env@npm:15.4.10":
+  version: 15.4.10
+  resolution: "@next/env@npm:15.4.10"
+  checksum: 10c0/f455f9630f56691800441333bf1462135f64eba65cc81a34fceedb42fcc62fd22fb2dfaa8de49f65b378fc46c5cf35795c0a32363006b989806223856be221fa
   languageName: node
   linkType: hard
 
@@ -6703,7 +6703,7 @@ __metadata:
     i18next-browser-languagedetector: "npm:^8.0.4"
     lodash: "npm:^4.17.21"
     markdown-to-txt: "npm:^2.0.1"
-    next: "npm:15.4.8"
+    next: "npm:15.4.10"
     next-auth: "npm:^5.0.0-beta.29"
     next-mdx-remote: "npm:^5.0.0"
     pdfjs-dist: "npm:5.3.93"
@@ -7410,11 +7410,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:15.4.8":
-  version: 15.4.8
-  resolution: "next@npm:15.4.8"
+"next@npm:15.4.10":
+  version: 15.4.10
+  resolution: "next@npm:15.4.10"
   dependencies:
-    "@next/env": "npm:15.4.8"
+    "@next/env": "npm:15.4.10"
     "@next/swc-darwin-arm64": "npm:15.4.8"
     "@next/swc-darwin-x64": "npm:15.4.8"
     "@next/swc-linux-arm64-gnu": "npm:15.4.8"
@@ -7465,7 +7465,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/4bbeb66d2db81f7f8580b3db0e14569bf09d71b958a3c65ddfb23015f316f3b85a4bf32349c9d21b03a61cd31b7d4e19829ff625b71dbde6ab0aa8db60bacd90
+  checksum: 10c0/67101363146d48f6e532b7b4d15df6d6a02601782037e4f9013f620a3cb046231a0db986bd983e1726b95aa30d10d02f673f9f123188582fe7c42d1fe94d74d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://nextjs.org/blog/security-update-2025-12-11
